### PR TITLE
feat: Support dynamic documentTitle via function callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ It is also possible to lazy set the ref if your content being printed is dynamic
 | **`bodyClass`** | `string` | One or more class names to pass to the print window, separated by spaces |
 | **`contentRef`** | `React.RefObject<Element \| Text>` | The ref pointing to the content to be printed. Alternatively, pass the ref directly to the callback returned by `useReactToPrint` |
 | **`copyShadowRoots`** | `boolean` | Copy shadow root content into the print window. Warning: Use with care if you print large documents as traversing these can be slow. |
-| **`documentTitle`** | `string` | Set the title for printing when saving as a file |
+| **`documentTitle`** | `string \| (() => string)` | Set the title for printing when saving as a file. Can be a static string or a function that returns a string, which will be evaluated at print time. This is useful for including dynamic data like timestamps. Ignored when passing a custom `print` option |
 | **`fonts`** | `{ family: string, source: string; weight?: string; style?: string; }[]` | A list of fonts to load into the printing iframe. This is useful if you are using custom fonts |
 | **`ignoreGlobalStyles`** | `boolean` | Ignore all `<style>` and `<link type="stylesheet" />` tags |
 | **`nonce`** | `string` | Set the [`nonce`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce) attribute for allow-listing script and style elements for Content Security Policy (CSP) |
@@ -95,6 +95,19 @@ We are actively researching resolutions to this issue, but it likely requires ch
 - When rendering multiple components to print, ensure each is passed a unique ref. Then, either use a unique `useReactToPrint` call for each component, or, using a single `useReactToPrint` call pass the refs at print-time to the printing function returned by the hook. If you share refs across components only the last component will be printed. See [323](https://github.com/MatthewHerbst/react-to-print/issues/323) for more.
 
 ## FAQ
+
+### How can I use dynamic content in `documentTitle`?
+
+You can pass a function to `documentTitle` that returns a string. This function will be evaluated at print time, allowing you to include dynamic data like timestamps or user information.
+
+```tsx
+const printFn = useReactToPrint({
+  contentRef: componentRef,
+  documentTitle: () => `Invoice_${new Date().toISOString().split('T')[0]}`,
+});
+```
+
+This will generate filenames like `Invoice_2026-02-03.pdf` with the current date when printing.
 
 ### How can content be hidden/shown during printing?
 

--- a/examples/DynamicDocumentTitle/index.tsx
+++ b/examples/DynamicDocumentTitle/index.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+
+import { ComponentToPrint } from "../ComponentToPrint";
+import { CUSTOM_FONTS } from "../fonts";
+import { useReactToPrint } from "../../src/hooks/useReactToPrint";
+
+export const DynamicDocumentTitle = () => {
+  const componentRef = React.useRef<HTMLDivElement>(null);
+
+  const handleAfterPrint = React.useCallback(() => {
+    console.log("`onAfterPrint` called");
+  }, []);
+
+  const handleBeforePrint = React.useCallback(() => {
+    console.log("`onBeforePrint` called");
+    return Promise.resolve();
+  }, []);
+
+  const printFn = useReactToPrint({
+    contentRef: componentRef,
+    documentTitle: () => {
+      const now = new Date();
+      const timestamp = now.toISOString().replace(/[:.]/g, '-');
+      return `PrintedDocument_${timestamp}`;
+    },
+    fonts: CUSTOM_FONTS,
+    onAfterPrint: handleAfterPrint,
+    onBeforePrint: handleBeforePrint,
+  }); 
+
+  return (
+    <div>
+      <button onClick={printFn}>Print with Dynamic Timestamp</button>
+      <ComponentToPrint ref={componentRef} />
+    </div>
+  );
+};

--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -8,7 +8,8 @@ import { CustomPrint } from "./CustomPrint";
 import { LazyContent } from "./LazyContent/index";
 import "./styles/index.css";
 import { OnBeforePrint } from './OnBeforePrint';
-import {CopyShadowRootContent} from "./CopyShadowRootContent";
+import { CopyShadowRootContent } from "./CopyShadowRootContent";
+import { DynamicDocumentTitle } from "./DynamicDocumentTitle";
 
 function Example() {
   return (
@@ -21,12 +22,14 @@ function Example() {
           <Tab>Lazy Content</Tab>
           <Tab>On Before Print</Tab>
           <Tab>Copy Shadow Root Content</Tab>
+          <Tab>Dynamic Document Title</Tab>
         </TabList>
         <TabPanel><BasicComponent /></TabPanel>
         <TabPanel><CustomPrint /></TabPanel>
         <TabPanel><LazyContent /></TabPanel>
         <TabPanel><OnBeforePrint /></TabPanel>
         <TabPanel><CopyShadowRootContent /></TabPanel>
+        <TabPanel><DynamicDocumentTitle /></TabPanel>
       </Tabs>
     </div>
   );

--- a/src/hooks/useReactToPrint.ts
+++ b/src/hooks/useReactToPrint.ts
@@ -33,11 +33,15 @@ export function useReactToPrint({
         removePrintIframe(preserveAfterPrint, true);
 
         function beginPrint() {
+            const resolvedDocumentTitle: string | undefined = typeof documentTitle === 'function' 
+                ? documentTitle() 
+                : documentTitle;
+            
             const options: UseReactToPrintOptions = {
                 bodyClass,
                 contentRef,
                 copyShadowRoots,
-                documentTitle,
+                documentTitle: resolvedDocumentTitle,
                 fonts,
                 ignoreGlobalStyles,
                 nonce,

--- a/src/types/UseReactToPrintOptions.ts
+++ b/src/types/UseReactToPrintOptions.ts
@@ -12,8 +12,12 @@ export interface UseReactToPrintOptions {
      * callback returned by `useReactToPrint`
      */
     contentRef?: RefObject<ContentNode>;
-    /** Set the title for printing when saving as a file. Ignored when passing a custom `print` option */
-    documentTitle?: string;
+    /** 
+     * Set the title for printing when saving as a file. 
+     * Can be a static string or a function that returns a string (evaluated at print time).
+     * Ignored when passing a custom `print` option 
+     */
+    documentTitle?: string | (() => string);
     /** A list of fonts to load into the printing iframe. This is useful if you are using custom fonts */
     fonts?: Font[];
     /** Ignore all `<style>` and `<link type="stylesheet" />` tags from `<head>` */

--- a/src/utils/startPrint.ts
+++ b/src/utils/startPrint.ts
@@ -49,24 +49,28 @@ export function startPrint(printWindow: HTMLIFrameElement, options: UseReactToPr
                     const tempContentDocumentTitle = printWindow.contentDocument?.title ?? '';
                     const tempOwnerDocumentTitle = printWindow.ownerDocument.title;
 
+                    const resolvedTitle = typeof documentTitle === 'function' 
+                        ? documentTitle() 
+                        : documentTitle;
+
                     // Override page and various target content titles during print
                     // NOTE: some browsers seem to take the print title from the highest level
                     // title, while others take it from the lowest level title. So, we set the title
                     // in a few places and hope the current browser takes one of them :pray:
-                    if (documentTitle) {
+                    if (resolvedTitle) {
                         // Print filename in Chrome
-                        printWindow.ownerDocument.title = documentTitle;
+                        printWindow.ownerDocument.title = resolvedTitle;
 
                         // Print filename in Firefox, Safari
                         if (printWindow.contentDocument) {
-                            printWindow.contentDocument.title = documentTitle;
+                            printWindow.contentDocument.title = resolvedTitle;
                         }
                     }
 
                     printWindow.contentWindow.print();
 
                     // Restore the page's original title information
-                    if (documentTitle) {
+                    if (resolvedTitle) {
                         printWindow.ownerDocument.title = tempOwnerDocumentTitle;
 
                         if (printWindow.contentDocument) {


### PR DESCRIPTION
Closes https://github.com/MatthewHerbst/react-to-print/issues/832

## Summary
This PR adds support for dynamic `documentTitle` by allowing it to accept a function callback in addition to the existing string type.
##  Motivation
Users need to include dynamic data (timestamps, user info, etc.) in print filenames. Currently, `documentTitle` is captured at hook initialization, making this impossible without recreating the hook.
 ## Changes
- ✅ Modified `UseReactToPrintOptions` type to support `string | (() => string)`
- ✅ Updated `useReactToPrint` hook to evaluate function callbacks at print time
- ✅ Updated `startPrint` to handle function type resolution
- ✅ Added `DynamicDocumentTitle` example demonstrating timestamp usage
- ✅ Updated README documentation with new usage examples
- ✅ Maintains 100% backward compatibility
 ## Usage Example
const printFn = useReactToPrint({
  contentRef: componentRef,
  documentTitle: () => `Invoice_${new Date().toISOString().split('T')[0]}`,
});
This generates filenames like Invoice_2026-02-03.pdf with the current date when printing.
## Testing
- ✅ All existing lint checks pass
- ✅ TypeScript type checking passes
- ✅ Verified backward compatibility with string type
- ✅ No breaking changes